### PR TITLE
Enabled JWT Auth Guards across API Endpoints

### DIFF
--- a/src/organization-keys/organization-keys.controller.ts
+++ b/src/organization-keys/organization-keys.controller.ts
@@ -28,8 +28,8 @@ export class OrganizationKeysController {
     private readonly organizationKeysService: OrganizationKeysService,
   ) {}
 
-  //@UseGuards(JwtAuthGuard)
-  //@ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
   @ApiOkResponse()
   @ApiNotFoundResponse()
   @UseInterceptors(ClassSerializerInterceptor)
@@ -38,8 +38,8 @@ export class OrganizationKeysController {
     return this.organizationKeysService.create(createOrganizationKeyDto)
   }
 
-  //@UseGuards(JwtAuthGuard)
-  //@ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
   @ApiOkResponse()
   @ApiNotFoundResponse()
   @UseInterceptors(ClassSerializerInterceptor)
@@ -48,8 +48,8 @@ export class OrganizationKeysController {
     return this.organizationKeysService.findAll()
   }
 
-  //@UseGuards(JwtAuthGuard)
-  //@ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
   @ApiOkResponse()
   @ApiNotFoundResponse()
   @UseInterceptors(ClassSerializerInterceptor)
@@ -58,8 +58,8 @@ export class OrganizationKeysController {
     return this.organizationKeysService.findByKey(authorizationKey)
   }
 
-  //@UseGuards(JwtAuthGuard)
-  //@ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
   @ApiOkResponse()
   @ApiNotFoundResponse()
   @UseInterceptors(ClassSerializerInterceptor)
@@ -68,8 +68,8 @@ export class OrganizationKeysController {
     return this.organizationKeysService.findOne(id)
   }
 
-  //@UseGuards(JwtAuthGuard)
-  //@ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
   @ApiOkResponse()
   @ApiNotFoundResponse()
   @UseInterceptors(ClassSerializerInterceptor)

--- a/src/organization-users/organization-users.controller.ts
+++ b/src/organization-users/organization-users.controller.ts
@@ -28,8 +28,8 @@ export class OrganizationUsersController {
     private readonly organizationUsersService: OrganizationUsersService,
   ) {}
 
-  //@UseGuards(JwtAuthGuard)
-  //@ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
   @ApiOkResponse()
   @ApiNotFoundResponse()
   @UseInterceptors(ClassSerializerInterceptor)
@@ -38,8 +38,8 @@ export class OrganizationUsersController {
     return this.organizationUsersService.create(createOrganizationUserDto)
   }
 
-  //@UseGuards(JwtAuthGuard)
-  //@ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
   @ApiOkResponse()
   @ApiNotFoundResponse()
   @UseInterceptors(ClassSerializerInterceptor)
@@ -48,8 +48,8 @@ export class OrganizationUsersController {
     return this.organizationUsersService.findAll()
   }
 
-  //@UseGuards(JwtAuthGuard)
-  //@ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
   @ApiOkResponse()
   @ApiNotFoundResponse()
   @UseInterceptors(ClassSerializerInterceptor)
@@ -58,8 +58,8 @@ export class OrganizationUsersController {
     return this.organizationUsersService.findByUserId(id)
   }
 
-  //@UseGuards(JwtAuthGuard)
-  //@ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
   @ApiOkResponse()
   @ApiNotFoundResponse()
   @UseInterceptors(ClassSerializerInterceptor)
@@ -68,8 +68,8 @@ export class OrganizationUsersController {
     return this.organizationUsersService.findOne(id)
   }
 
-  //@UseGuards(JwtAuthGuard)
-  //@ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
   @ApiOkResponse()
   @ApiNotFoundResponse()
   @UseInterceptors(ClassSerializerInterceptor)

--- a/src/organizations/organizations.controller.ts
+++ b/src/organizations/organizations.controller.ts
@@ -9,7 +9,6 @@ import {
   ClassSerializerInterceptor,
   UseGuards,
   UseInterceptors,
-  Put,
 } from '@nestjs/common'
 import { OrganizationsService } from './organizations.service'
 import { CreateOrganizationDto } from './dto/create-organization.dto'
@@ -27,8 +26,8 @@ import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard'
 export class OrganizationsController {
   constructor(private readonly organizationsService: OrganizationsService) {}
 
-  //@UseGuards(JwtAuthGuard)
-  //@ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
   @ApiOkResponse()
   @ApiNotFoundResponse()
   @UseInterceptors(ClassSerializerInterceptor)
@@ -53,8 +52,8 @@ export class OrganizationsController {
     )
   }
 
-  //@UseGuards(JwtAuthGuard)
-  //@ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
   @ApiOkResponse()
   @ApiNotFoundResponse()
   @UseInterceptors(ClassSerializerInterceptor)
@@ -63,8 +62,8 @@ export class OrganizationsController {
     return this.organizationsService.findAll()
   }
 
-  //@UseGuards(JwtAuthGuard)
-  //@ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
   @ApiOkResponse()
   @ApiNotFoundResponse()
   @UseInterceptors(ClassSerializerInterceptor)
@@ -73,8 +72,8 @@ export class OrganizationsController {
     return this.organizationsService.findByDocument(document)
   }
 
-  //@UseGuards(JwtAuthGuard)
-  //@ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
   @ApiOkResponse()
   @ApiNotFoundResponse()
   @UseInterceptors(ClassSerializerInterceptor)
@@ -83,8 +82,8 @@ export class OrganizationsController {
     return this.organizationsService.findOne(id)
   }
 
-  //@UseGuards(JwtAuthGuard)
-  //@ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
   @ApiOkResponse()
   @ApiNotFoundResponse()
   @UseInterceptors(ClassSerializerInterceptor)

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -26,8 +26,8 @@ import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard'
 export class UsersController {
   constructor(private readonly usersService: UsersService) {}
 
-  //@UseGuards(JwtAuthGuard)
-  //@ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
   @ApiOkResponse()
   @ApiNotFoundResponse()
   @UseInterceptors(ClassSerializerInterceptor)
@@ -36,8 +36,8 @@ export class UsersController {
     return this.usersService.create(createUserDto)
   }
 
-  //@UseGuards(JwtAuthGuard)
-  //@ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
   @ApiOkResponse()
   @ApiNotFoundResponse()
   @UseInterceptors(ClassSerializerInterceptor)
@@ -46,8 +46,8 @@ export class UsersController {
     return this.usersService.findAll()
   }
 
-  //@UseGuards(JwtAuthGuard)
-  //@ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
   @ApiOkResponse()
   @ApiNotFoundResponse()
   @UseInterceptors(ClassSerializerInterceptor)
@@ -56,8 +56,8 @@ export class UsersController {
     return this.usersService.findByEmail(email)
   }
 
-  //@UseGuards(JwtAuthGuard)
-  //@ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
   @ApiOkResponse()
   @ApiNotFoundResponse()
   @UseInterceptors(ClassSerializerInterceptor)
@@ -66,8 +66,8 @@ export class UsersController {
     return this.usersService.findById(id)
   }
 
-  //@UseGuards(JwtAuthGuard)
-  //@ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
   @ApiOkResponse()
   @ApiNotFoundResponse()
   @UseInterceptors(ClassSerializerInterceptor)
@@ -76,8 +76,8 @@ export class UsersController {
     return this.usersService.findByPhone(phone)
   }
 
-  //@UseGuards(JwtAuthGuard)
-  //@ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
   @ApiOkResponse()
   @ApiNotFoundResponse()
   @UseInterceptors(ClassSerializerInterceptor)


### PR DESCRIPTION
Enabled JWT authentication and bearer token authorization for all controller methods in the OrganizationKeys, OrganizationUsers, Organizations, and Users modules by uncommenting the relevant decorators. This enforces access control for better security, ensuring that only authenticated and authorized users can invoke these endpoints.