### PR TITLE
Enhance access control with profiles

### DIFF
--- a/src/auth/guards/profile-auth.guard.ts
+++ b/src/auth/guards/profile-auth.guard.ts
@@ -1,0 +1,26 @@
+import { PROFILES_KEY } from './../../users/decorators/user.decorator'
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common'
+import { Reflector } from '@nestjs/core'
+import { Observable } from 'rxjs'
+import { UserProfileEnum } from 'src/users/users.enumerator'
+
+@Injectable()
+export class ProfileAuthGuard implements CanActivate {
+  constructor(private reflector: Reflector) {}
+
+  canActivate(
+    context: ExecutionContext,
+  ): boolean | Promise<boolean> | Observable<boolean> {
+    const requiredProfile = this.reflector.getAllAndOverride<UserProfileEnum[]>(
+      PROFILES_KEY,
+      [context.getHandler(), context.getClass()],
+    )
+    if (!requiredProfile) {
+      return true
+    }
+
+    const { user } = context.switchToHttp().getRequest()
+
+    return requiredProfile.some((profile) => user.profile?.includes(profile))
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,11 +29,6 @@ async function bootstrap() {
       in: 'header',
       description: 'authorization',
     })
-    .addApiKey({
-      type: 'apiKey',
-      in: 'header',
-      description: 'authorization',
-    })
     .build()
 
   const document = SwaggerModule.createDocument(app, options)

--- a/src/organization-keys/organization-keys.controller.ts
+++ b/src/organization-keys/organization-keys.controller.ts
@@ -20,6 +20,9 @@ import {
   ApiTags,
 } from '@nestjs/swagger'
 import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard'
+import { ProfileAuthGuard } from 'src/auth/guards/profile-auth.guard'
+import { Profiles } from 'src/users/decorators/user.decorator'
+import { UserProfileEnum } from 'src/users/users.enumerator'
 
 @ApiTags('organization-keys')
 @Controller('organization-keys')
@@ -28,7 +31,8 @@ export class OrganizationKeysController {
     private readonly organizationKeysService: OrganizationKeysService,
   ) {}
 
-  @UseGuards(JwtAuthGuard)
+  @Profiles(UserProfileEnum.master, UserProfileEnum.member)
+  @UseGuards(JwtAuthGuard, ProfileAuthGuard)
   @ApiBearerAuth()
   @ApiOkResponse()
   @ApiNotFoundResponse()
@@ -38,7 +42,8 @@ export class OrganizationKeysController {
     return this.organizationKeysService.create(createOrganizationKeyDto)
   }
 
-  @UseGuards(JwtAuthGuard)
+  @Profiles(UserProfileEnum.master, UserProfileEnum.member)
+  @UseGuards(JwtAuthGuard, ProfileAuthGuard)
   @ApiBearerAuth()
   @ApiOkResponse()
   @ApiNotFoundResponse()
@@ -48,7 +53,12 @@ export class OrganizationKeysController {
     return this.organizationKeysService.findAll()
   }
 
-  @UseGuards(JwtAuthGuard)
+  @Profiles(
+    UserProfileEnum.master,
+    UserProfileEnum.member,
+    UserProfileEnum.consumer,
+  )
+  @UseGuards(JwtAuthGuard, ProfileAuthGuard)
   @ApiBearerAuth()
   @ApiOkResponse()
   @ApiNotFoundResponse()
@@ -58,7 +68,12 @@ export class OrganizationKeysController {
     return this.organizationKeysService.findByKey(authorizationKey)
   }
 
-  @UseGuards(JwtAuthGuard)
+  @Profiles(
+    UserProfileEnum.master,
+    UserProfileEnum.member,
+    UserProfileEnum.consumer,
+  )
+  @UseGuards(JwtAuthGuard, ProfileAuthGuard)
   @ApiBearerAuth()
   @ApiOkResponse()
   @ApiNotFoundResponse()
@@ -68,7 +83,8 @@ export class OrganizationKeysController {
     return this.organizationKeysService.findOne(id)
   }
 
-  @UseGuards(JwtAuthGuard)
+  @Profiles(UserProfileEnum.master, UserProfileEnum.member)
+  @UseGuards(JwtAuthGuard, ProfileAuthGuard)
   @ApiBearerAuth()
   @ApiOkResponse()
   @ApiNotFoundResponse()
@@ -81,7 +97,8 @@ export class OrganizationKeysController {
     return this.organizationKeysService.update(id, updateOrganizationKeyDto)
   }
 
-  @UseGuards(JwtAuthGuard)
+  @Profiles(UserProfileEnum.master)
+  @UseGuards(JwtAuthGuard, ProfileAuthGuard)
   @ApiBearerAuth()
   @ApiOkResponse()
   @ApiNotFoundResponse()

--- a/src/organization-users/organization-users.controller.ts
+++ b/src/organization-users/organization-users.controller.ts
@@ -20,6 +20,9 @@ import {
   ApiTags,
 } from '@nestjs/swagger'
 import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard'
+import { ProfileAuthGuard } from 'src/auth/guards/profile-auth.guard'
+import { Profiles } from 'src/users/decorators/user.decorator'
+import { UserProfileEnum } from 'src/users/users.enumerator'
 
 @ApiTags('organization-users')
 @Controller('organization-users')
@@ -28,7 +31,12 @@ export class OrganizationUsersController {
     private readonly organizationUsersService: OrganizationUsersService,
   ) {}
 
-  @UseGuards(JwtAuthGuard)
+  @Profiles(
+    UserProfileEnum.master,
+    UserProfileEnum.member,
+    UserProfileEnum.consumer,
+  )
+  @UseGuards(JwtAuthGuard, ProfileAuthGuard)
   @ApiBearerAuth()
   @ApiOkResponse()
   @ApiNotFoundResponse()
@@ -38,7 +46,12 @@ export class OrganizationUsersController {
     return this.organizationUsersService.create(createOrganizationUserDto)
   }
 
-  @UseGuards(JwtAuthGuard)
+  @Profiles(
+    UserProfileEnum.master,
+    UserProfileEnum.member,
+    UserProfileEnum.consumer,
+  )
+  @UseGuards(JwtAuthGuard, ProfileAuthGuard)
   @ApiBearerAuth()
   @ApiOkResponse()
   @ApiNotFoundResponse()
@@ -48,7 +61,12 @@ export class OrganizationUsersController {
     return this.organizationUsersService.findAll()
   }
 
-  @UseGuards(JwtAuthGuard)
+  @Profiles(
+    UserProfileEnum.master,
+    UserProfileEnum.member,
+    UserProfileEnum.consumer,
+  )
+  @UseGuards(JwtAuthGuard, ProfileAuthGuard)
   @ApiBearerAuth()
   @ApiOkResponse()
   @ApiNotFoundResponse()
@@ -58,7 +76,12 @@ export class OrganizationUsersController {
     return this.organizationUsersService.findByUserId(id)
   }
 
-  @UseGuards(JwtAuthGuard)
+  @Profiles(
+    UserProfileEnum.master,
+    UserProfileEnum.member,
+    UserProfileEnum.consumer,
+  )
+  @UseGuards(JwtAuthGuard, ProfileAuthGuard)
   @ApiBearerAuth()
   @ApiOkResponse()
   @ApiNotFoundResponse()
@@ -68,7 +91,12 @@ export class OrganizationUsersController {
     return this.organizationUsersService.findOne(id)
   }
 
-  @UseGuards(JwtAuthGuard)
+  @Profiles(
+    UserProfileEnum.master,
+    UserProfileEnum.member,
+    UserProfileEnum.consumer,
+  )
+  @UseGuards(JwtAuthGuard, ProfileAuthGuard)
   @ApiBearerAuth()
   @ApiOkResponse()
   @ApiNotFoundResponse()
@@ -81,8 +109,8 @@ export class OrganizationUsersController {
     return this.organizationUsersService.update(id, updateOrganizationUserDto)
   }
 
-  @UseGuards(JwtAuthGuard)
-  @ApiBearerAuth()
+  @Profiles(UserProfileEnum.master)
+  @UseGuards(JwtAuthGuard, ProfileAuthGuard)
   @ApiOkResponse()
   @ApiNotFoundResponse()
   @UseInterceptors(ClassSerializerInterceptor)

--- a/src/organizations/dto/update-organization.dto.ts
+++ b/src/organizations/dto/update-organization.dto.ts
@@ -1,4 +1,4 @@
-import { PartialType } from '@nestjs/swagger';
-import { CreateOrganizationDto } from './create-organization.dto';
+import { PartialType } from '@nestjs/swagger'
+import { CreateOrganizationDto } from './create-organization.dto'
 
 export class UpdateOrganizationDto extends PartialType(CreateOrganizationDto) {}

--- a/src/organizations/organizations.controller.ts
+++ b/src/organizations/organizations.controller.ts
@@ -20,13 +20,21 @@ import {
   ApiTags,
 } from '@nestjs/swagger'
 import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard'
+import { ProfileAuthGuard } from 'src/auth/guards/profile-auth.guard'
+import { Profiles } from 'src/users/decorators/user.decorator'
+import { UserProfileEnum } from 'src/users/users.enumerator'
 
 @ApiTags('organizations')
 @Controller('organizations')
 export class OrganizationsController {
   constructor(private readonly organizationsService: OrganizationsService) {}
 
-  @UseGuards(JwtAuthGuard)
+  @Profiles(
+    UserProfileEnum.master,
+    UserProfileEnum.member,
+    UserProfileEnum.consumer,
+  )
+  @UseGuards(JwtAuthGuard, ProfileAuthGuard)
   @ApiBearerAuth()
   @ApiOkResponse()
   @ApiNotFoundResponse()
@@ -52,7 +60,12 @@ export class OrganizationsController {
     )
   }
 
-  @UseGuards(JwtAuthGuard)
+  @Profiles(
+    UserProfileEnum.master,
+    UserProfileEnum.member,
+    UserProfileEnum.consumer,
+  )
+  @UseGuards(JwtAuthGuard, ProfileAuthGuard)
   @ApiBearerAuth()
   @ApiOkResponse()
   @ApiNotFoundResponse()
@@ -62,7 +75,13 @@ export class OrganizationsController {
     return this.organizationsService.findAll()
   }
 
-  @UseGuards(JwtAuthGuard)
+  @Profiles(
+    UserProfileEnum.master,
+    UserProfileEnum.member,
+    UserProfileEnum.consumer,
+    UserProfileEnum.guest,
+  )
+  @UseGuards(JwtAuthGuard, ProfileAuthGuard)
   @ApiBearerAuth()
   @ApiOkResponse()
   @ApiNotFoundResponse()
@@ -72,7 +91,12 @@ export class OrganizationsController {
     return this.organizationsService.findByDocument(document)
   }
 
-  @UseGuards(JwtAuthGuard)
+  @Profiles(
+    UserProfileEnum.master,
+    UserProfileEnum.member,
+    UserProfileEnum.consumer,
+  )
+  @UseGuards(JwtAuthGuard, ProfileAuthGuard)
   @ApiBearerAuth()
   @ApiOkResponse()
   @ApiNotFoundResponse()
@@ -82,7 +106,12 @@ export class OrganizationsController {
     return this.organizationsService.findOne(id)
   }
 
-  @UseGuards(JwtAuthGuard)
+  @Profiles(
+    UserProfileEnum.master,
+    UserProfileEnum.member,
+    UserProfileEnum.consumer,
+  )
+  @UseGuards(JwtAuthGuard, ProfileAuthGuard)
   @ApiBearerAuth()
   @ApiOkResponse()
   @ApiNotFoundResponse()
@@ -95,7 +124,8 @@ export class OrganizationsController {
     return this.organizationsService.update(id, updateOrganizationDto)
   }
 
-  @UseGuards(JwtAuthGuard)
+  @Profiles(UserProfileEnum.master)
+  @UseGuards(JwtAuthGuard, ProfileAuthGuard)
   @ApiBearerAuth()
   @ApiOkResponse()
   @ApiNotFoundResponse()

--- a/src/organizations/repositories/update-organization.repository.ts
+++ b/src/organizations/repositories/update-organization.repository.ts
@@ -16,7 +16,7 @@ export const updateOrganizationRepository = async (
 
     await prisma.organization.update({
       where: { id: id },
-      data: updateOrganizationDto,
+      data: { ...updateOrganizationDto },
     })
     return JSON.stringify(`as informações da organização foram atualizadas`)
   } catch (error) {

--- a/src/users/decorators/user.decorator.ts
+++ b/src/users/decorators/user.decorator.ts
@@ -1,0 +1,6 @@
+import { SetMetadata } from '@nestjs/common'
+import { UserProfile } from '@prisma/client'
+
+export const PROFILES_KEY = 'profiles'
+export const Profiles = (...profiles: UserProfile[]) =>
+  SetMetadata(PROFILES_KEY, profiles)

--- a/src/users/dto/create-user.dto.ts
+++ b/src/users/dto/create-user.dto.ts
@@ -16,6 +16,16 @@ export class CreateUserDto {
   @IsOptional()
   active: boolean
 
+  @ApiPropertyOptional({ default: false })
+  @IsBoolean()
+  @IsOptional()
+  subscriber: boolean
+
+  @ApiPropertyOptional({ default: false })
+  @IsBoolean()
+  @IsOptional()
+  suspended: boolean
+
   @ApiPropertyOptional({ default: 'guest', enum: $Enums.UserProfile })
   @IsEnum($Enums.UserProfile)
   @IsOptional()

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -20,13 +20,17 @@ import {
   ApiTags,
 } from '@nestjs/swagger'
 import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard'
+import { ProfileAuthGuard } from 'src/auth/guards/profile-auth.guard'
+import { Profiles } from './decorators/user.decorator'
+import { UserProfileEnum } from './users.enumerator'
 
 @ApiTags('users')
 @Controller('users')
 export class UsersController {
   constructor(private readonly usersService: UsersService) {}
 
-  @UseGuards(JwtAuthGuard)
+  @Profiles(UserProfileEnum.master)
+  @UseGuards(JwtAuthGuard, ProfileAuthGuard)
   @ApiBearerAuth()
   @ApiOkResponse()
   @ApiNotFoundResponse()
@@ -36,7 +40,8 @@ export class UsersController {
     return this.usersService.create(createUserDto)
   }
 
-  @UseGuards(JwtAuthGuard)
+  @Profiles(UserProfileEnum.master)
+  @UseGuards(JwtAuthGuard, ProfileAuthGuard)
   @ApiBearerAuth()
   @ApiOkResponse()
   @ApiNotFoundResponse()
@@ -46,7 +51,8 @@ export class UsersController {
     return this.usersService.findAll()
   }
 
-  @UseGuards(JwtAuthGuard)
+  @Profiles(UserProfileEnum.master, UserProfileEnum.member)
+  @UseGuards(JwtAuthGuard, ProfileAuthGuard)
   @ApiBearerAuth()
   @ApiOkResponse()
   @ApiNotFoundResponse()
@@ -56,7 +62,8 @@ export class UsersController {
     return this.usersService.findByEmail(email)
   }
 
-  @UseGuards(JwtAuthGuard)
+  @Profiles(UserProfileEnum.master, UserProfileEnum.member)
+  @UseGuards(JwtAuthGuard, ProfileAuthGuard)
   @ApiBearerAuth()
   @ApiOkResponse()
   @ApiNotFoundResponse()
@@ -66,7 +73,8 @@ export class UsersController {
     return this.usersService.findById(id)
   }
 
-  @UseGuards(JwtAuthGuard)
+  @Profiles(UserProfileEnum.master, UserProfileEnum.member)
+  @UseGuards(JwtAuthGuard, ProfileAuthGuard)
   @ApiBearerAuth()
   @ApiOkResponse()
   @ApiNotFoundResponse()
@@ -76,7 +84,13 @@ export class UsersController {
     return this.usersService.findByPhone(phone)
   }
 
-  @UseGuards(JwtAuthGuard)
+  @Profiles(
+    UserProfileEnum.master,
+    UserProfileEnum.member,
+    UserProfileEnum.consumer,
+    UserProfileEnum.guest,
+  )
+  @UseGuards(JwtAuthGuard, ProfileAuthGuard)
   @ApiBearerAuth()
   @ApiOkResponse()
   @ApiNotFoundResponse()
@@ -86,7 +100,8 @@ export class UsersController {
     return this.usersService.update(id, updateUserDto)
   }
 
-  @UseGuards(JwtAuthGuard)
+  @Profiles(UserProfileEnum.master)
+  @UseGuards(JwtAuthGuard, ProfileAuthGuard)
   @ApiBearerAuth()
   @ApiOkResponse()
   @ApiNotFoundResponse()

--- a/src/users/users.enumerator.ts
+++ b/src/users/users.enumerator.ts
@@ -1,0 +1,6 @@
+export enum UserProfileEnum {
+  guest = 'guest',
+  consumer = 'consumer',
+  member = 'member',
+  master = 'master',
+}


### PR DESCRIPTION
Refined the authorization strategy across different controllers by
integrating ProfileAuthGuard. API routes in organizations,
organization-keys, organization-users, and users controllers are now
reinforced with profile-based permissions, ensuring that only users with
specific roles (master, member, consumer, and guest) can access certain
endpoints. Removed a redundant API key setup from main.ts to clean up
the Swagger configuration.

This change addresses the need for granular access control and improves
the security posture by adhering to the principle of least privilege.